### PR TITLE
adding apps.py with verbose name so things in admin look less awkward

### DIFF
--- a/kubernetes_manager/__init__.py
+++ b/kubernetes_manager/__init__.py
@@ -1,1 +1,2 @@
 __version__ = "0.4.0"
+default_app_config = "kubernetes_manager.apps.KubernetesManagerConfig"

--- a/kubernetes_manager/apps.py
+++ b/kubernetes_manager/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class KubernetesManagerConfig(AppConfig):
+    name = "kubernetes_manager"
+    verbose_name = "Kubernetes Manager"
+
+    def ready(self):
+        pass


### PR DESCRIPTION
Django app needed an apps.py for various reasons... but I put it in there so that it'd show something more friendly in django admin.